### PR TITLE
Delete yjit-3.1.0-dev

### DIFF
--- a/rubies/yjit-3.1.0-dev
+++ b/rubies/yjit-3.1.0-dev
@@ -1,2 +1,0 @@
-install_package "openssl-1.1.1l" "https://www.openssl.org/source/openssl-1.1.1l.tar.gz#0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1" mac_openssl --if has_broken_mac_openssl
-install_git "ruby-master" "https://github.com/Shopify/yjit.git" "main" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl


### PR DESCRIPTION
It's weird that `ShopifyRubyDefinitions.version_overrides["yjit"]` returns `yjit-3.1.0-dev`. https://github.com/Shopify/yjit isn't buildable since all the content except the README was removed.