### PR TITLE
Add a new definition to build TruffleRuby integration branch from source.

### DIFF
--- a/rubies/truffleruby+graalvm-integration
+++ b/rubies/truffleruby+graalvm-integration
@@ -1,0 +1,8 @@
+build_package_jt() {
+    unset GEM_HOME GEM_PATH JAVA_HOME
+    JT_IMPORTS_DONT_ASK=true bin/jt build --env jvm
+    graalvm=$(bin/jt --use jvm ruby-home)
+    mv "$graalvm" "$PREFIX_PATH"
+}
+
+install_git "truffleruby+graalvm-integration" "https://github.com/Shopify/truffleruby.git" "integration" graalvm jt

--- a/rubies/truffleruby-integration
+++ b/rubies/truffleruby-integration
@@ -1,0 +1,8 @@
+build_package_jt() {
+    unset JAVA_HOME GEM_HOME GEM_PATH
+    JT_IMPORTS_DONT_ASK=true bin/jt build --env native
+    graalvm=$(bin/jt --use native ruby-home)
+    mv "$graalvm" "$PREFIX_PATH"
+}
+
+install_git "truffleruby-integration" "https://github.com/Shopify/truffleruby.git" "integration" jt

--- a/test/shopify_ruby_definitions/test_ruby_versions.rb
+++ b/test/shopify_ruby_definitions/test_ruby_versions.rb
@@ -15,6 +15,8 @@ module ShopifyRubyDefinitions
       end
 
       truffleruby_versions.each do |v|
+        next if v.include?("integration")
+
         assert_match(/\Atruffleruby(?:\+graalvm)?(?:-gftc)?(\-\d+\.\d+\.\d+|-dev)(?:\-ce)?\z/, v)
       end
     end


### PR DESCRIPTION
This PR adds a new definition to build TruffleRuby from an integration branch to make it easier to test out code that hasn't yet been merged upstream. The definition will not work until https://github.com/oracle/truffleruby/pull/3217 has been merged.