### PR TITLE
Add Ruby v3.2.2-pshopify12

### DIFF
--- a/rubies/3.2.2-pshopify12
+++ b/rubies/3.2.2-pshopify12
@@ -1,0 +1,50 @@
+# https://github.com/ruby/ruby/compare/ruby_3_2...Shopify:v3.2.2-pshopify12
+
+# Based off `ruby_3_2`, with backports of:
+#   @byroot [ruby/set] Avoid the `block or return` pattern to save Proc allocations https://github.com/ruby/set/pull/29
+#   @peterzhu2118 Keep shared arrays WB protected https://github.com/ruby/ruby/pull/7224
+#   @peterzhu2118 Make BigDecimal WB protected https://github.com/ruby/bigdecimal/pull/248
+#   @XrXr YJIT String#+@ fixes https://github.com/ruby/ruby/pull/7328
+#   @byroot Add RUBY_GC_HEAP_INIT_SIZE_%d_SLOTS to pre-init pools granularly https://github.com/ruby/ruby/pull/7235
+#   @byroot Consider DATA objects without a mark function as protected https://github.com/ruby/ruby/pull/7263
+#   @byroot Implement Write Barrier for RMatch objects https://github.com/ruby/ruby/pull/7286
+#   @byroot Enable write barriers on File::Stat https://github.com/ruby/ruby/pull/7239
+#   @byroot Implement Write Barrier for Backtrace::Location https://github.com/ruby/ruby/pull/7240
+#   @byroot Mark "mapping_buffer" as write barrier protected https://github.com/ruby/ruby/pull/7238
+#   @byroot Mark "method" objects as protected by write barrier https://github.com/ruby/ruby/pull/7237
+#   @byroot Mark Encoding as Write Barrier protected Mark Encoding as Write Barrier protected
+#   @peterzhu2118 Make Time objects WB protected https://github.com/ruby/ruby/pull/7244
+#   @jhawthorn Use write barriers for Backtrace objects
+#   @peterzhu2118 Crash when malloc during GC
+#   @peterzhu2118 Fix crash when allocating classes with newobj hook
+#   @peterzhu2118 [Bug #19469] Fix crash when resizing generic iv list
+#   @byroot Implement Write Barrier for autoload_data
+#   @byroot Implement Write Barrier for autoload_table_type
+#   @k0kubun YJIT: Protect strings from GC on String#<<
+#   @tenderlove Use an st table for "too complex" objects
+#   @byroot Cache `Process.pid`
+#   @byroot thread_pthread.c: Use a `fork_gen` to protect against fork instead of getpid()
+#   @XrXr Fix write barrier order for klass to cme edge https://github.com/ruby/ruby/pull/7113
+#   @peterzhu2118 Ensure throw data is not set as cause https://github.com/ruby/ruby/pull/7696
+#   @peterzhu2118 Fix crash in rb_gc_register_address https://github.com/ruby/ruby/pull/7670
+#   @peterzhu2118 [Feature #19678] Don't immediately promote children of old objects https://github.com/ruby/ruby/pull/7821
+#   @k0kubun YJIT: Use rb_ivar_get at the end of ivar chains https://github.com/ruby/ruby/pull/7334
+#   @k0kubun / @maximecb / @XrXr YJIT: Add --yjit-pause and RubyVM::YJIT.resume https://github.com/ruby/ruby/pull/7609
+#   @k0kubun YJIT: Make ratio_in_yjit always available https://github.com/ruby/ruby/pull/8064
+#   @peterzhu2118 Store initial slots per size pool https://github.com/ruby/ruby/pull/8116
+#   @k0kubun YJIT: Implement throw instruction https://github.com/ruby/ruby/pull/7491
+#   @k0kubun YJIT: Fallback send instructions to vm_sendish https://github.com/ruby/ruby/pull/8106
+#   @k0kubun YJIT: Support entry for multiple PCs per ISEQ https://github.com/ruby/ruby/pull/7535
+#   @k0kubun YJIT: Distinguish exit and fallback reasons for send https://github.com/ruby/ruby/pull/8159
+#   @k0kubun YJIT: Use dynamic dispatch for megamorphic send https://github.com/ruby/ruby/pull/8125
+#   @k0kubun YJIT: Compile exception handlers https://github.com/ruby/ruby/pull/8171
+#   @k0kubun YJIT: Introduce RubyVM::YJIT.stats_string https://github.com/ruby/ruby/pull/7857
+#   @k0kubun YJIT: Don't side-exit on too-complex shapes https://github.com/ruby/ruby/pull/7298
+#   @k0kubun YJIT: Distinguish exit and fallback reasons for invokesuper/invokeblock https://github.com/ruby/ruby/pull/8194
+#   @jhawthorn YJIT: invokesuper: Remove cme mid matching check https://github.com/ruby/ruby/pull/7740
+#   @k0kubun YJIT: Fallback megamorphic super/yield to dynamic dispatch https://github.com/ruby/ruby/pull/8197
+#   @maximecb YJIT: add stats for ratio of versions per block https://github.com/ruby/ruby/pull/7653
+#   @XrXr YJIT: YJIT: Fix false object collection when setting ivar https://github.com/ruby/ruby/pull/7718
+
+install_package "openssl-3.1.2" "https://www.openssl.org/source/openssl-3.1.2.tar.gz#a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539" openssl --if needs_openssl_102_300
+install_git "ruby-3.2.2-pshopify12" "https://github.com/Shopify/ruby.git" "v3.2.2-pshopify12" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl


### PR DESCRIPTION
Backports: https://github.com/ruby/ruby/pull/7718

This fixes a GC crash caused by YJIT. It generally manifest itself with a `[BUG] try to mark T_NONE object`.