### PR TITLE
Add 3.3.0-preview2-pshopify1

### DIFF
--- a/lib/shopify_ruby_definitions/ruby_versions.rb
+++ b/lib/shopify_ruby_definitions/ruby_versions.rb
@@ -2,13 +2,19 @@
 
 module ShopifyRubyDefinitions
   module RubyVersions
+    class << self
+      def build_version_overrides(all_versions)
+        all_versions.sort_by do |version|
+          version.scan(/\d+/).map(&:to_i)
+        end.to_h do |version|
+          [version.partition("-pshopify").first, version]
+        end.freeze
+      end
+    end
+
     VERSIONS_DIRECTORY = File.expand_path("../../../rubies", __FILE__)
     ALL_VERSIONS = Dir["#{VERSIONS_DIRECTORY}/*"].map { |f| File.basename(f) }
-    VERSION_OVERRIDES = ALL_VERSIONS.sort_by do |version|
-      version.scan(/\d+/).map(&:to_i)
-    end.to_h do |version|
-      [version.split("-").first, version]
-    end.freeze
+    VERSION_OVERRIDES = build_version_overrides(ALL_VERSIONS)
 
     def version_overrides
       VERSION_OVERRIDES

--- a/rubies/3.3.0-preview2-pshopify1
+++ b/rubies/3.3.0-preview2-pshopify1
@@ -1,0 +1,12 @@
+# https://github.com/ruby/ruby/compare/v3_3_0_preview2...Shopify:v3.3.0-preview2-pshopify1
+
+# Based off `v3_3_0_preview2`, with backports of:
+#   @nobu `.NOTPARALLEL` with prerequisites needs recent GNU Make https://github.com/ruby/ruby/pull/8489
+#   @k0kubun YJIT: Initialize Assembler vectors with capacity https://github.com/ruby/ruby/pull/8437
+#   @k0kubun YJIT: Initialize Vec with capacity for iterators https://github.com/ruby/ruby/pull/8439
+#   @k0kubun YJIT: Skip Insn::Comment and format! if disasm is disabled https://github.com/ruby/ruby/pull/8441
+#   @k0kubun YJIT: Avoid creating a vector in get_temp_regs() https://github.com/ruby/ruby/pull/8446
+#   @nobu Write crash report in $RUBY_CRASH_REPORT https://github.com/ruby/ruby/pull/8506
+
+install_package "openssl-3.1.2" "https://www.openssl.org/source/openssl-3.1.2.tar.gz#a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539" openssl --if needs_openssl_102_300
+install_git "ruby-3.3.0-preview2-pshopify1" "https://github.com/Shopify/ruby.git" "v3.3.0-preview2-pshopify1" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/test/shopify_ruby_definitions/test_ruby_versions.rb
+++ b/test/shopify_ruby_definitions/test_ruby_versions.rb
@@ -20,5 +20,29 @@ module ShopifyRubyDefinitions
     def test_resolve_version
       assert_equal("3.0.2-pshopify3", ShopifyRubyDefinitions.resolve_version("3.0"))
     end
+
+    def test_resolve_preview_version
+      with_versions(["3.3.0-preview2-pshopify1", "3.3.0-pshopify1"]) do
+        assert_equal("3.3.0-preview2-pshopify1", ShopifyRubyDefinitions.resolve_version("3.3.0-preview2"))
+        assert_equal("3.3.0-pshopify1", ShopifyRubyDefinitions.resolve_version("3.3"))
+      end
+    end
+
+    private
+
+    def with_versions(new_versions)
+      old_versions = RubyVersions::ALL_VERSIONS
+      old_version_overrides = RubyVersions::VERSION_OVERRIDES
+      RubyVersions.send(:remove_const, :ALL_VERSIONS)
+      RubyVersions.const_set(:ALL_VERSIONS, new_versions)
+      RubyVersions.send(:remove_const, :VERSION_OVERRIDES)
+      RubyVersions.const_set(:VERSION_OVERRIDES, RubyVersions.build_version_overrides(new_versions))
+      yield
+    ensure
+      RubyVersions.send(:remove_const, :ALL_VERSIONS)
+      RubyVersions.const_set(:ALL_VERSIONS, old_versions)
+      RubyVersions.send(:remove_const, :VERSION_OVERRIDES)
+      RubyVersions.const_set(:VERSION_OVERRIDES, old_version_overrides)
+    end
   end
 end


### PR DESCRIPTION
We're preparing for globally deploying 3.3.0-preview2 on SFR. 3.3.0-preview2 is fine as is, but I backported things that are nice to have and slipped from preview2.

* Parallelize `make` again:
    * https://github.com/ruby/ruby/pull/8489
* Speed up YJIT compilation:
    * https://github.com/ruby/ruby/pull/8437
    * https://github.com/ruby/ruby/pull/8439
    * https://github.com/ruby/ruby/pull/8441
    * https://github.com/ruby/ruby/pull/8446
* Crash report:
    * https://github.com/ruby/ruby/pull/8506