### PR TITLE
Add 3.3.0-preview2-pshopify3

### DIFF
--- a/rubies/3.3.0-preview2-pshopify3
+++ b/rubies/3.3.0-preview2-pshopify3
@@ -1,0 +1,14 @@
+# https://github.com/ruby/ruby/compare/v3_3_0_preview2...Shopify:v3.3.0-preview2-pshopify3
+
+# Based off `v3_3_0_preview2`, with backports of:
+#   @nobu `.NOTPARALLEL` with prerequisites needs recent GNU Make https://github.com/ruby/ruby/pull/8489
+#   @k0kubun YJIT: Initialize Assembler vectors with capacity https://github.com/ruby/ruby/pull/8437
+#   @k0kubun YJIT: Initialize Vec with capacity for iterators https://github.com/ruby/ruby/pull/8439
+#   @k0kubun YJIT: Skip Insn::Comment and format! if disasm is disabled https://github.com/ruby/ruby/pull/8441
+#   @k0kubun YJIT: Avoid creating a vector in get_temp_regs() https://github.com/ruby/ruby/pull/8446
+#   @nobu Write crash report in $RUBY_CRASH_REPORT https://github.com/ruby/ruby/pull/8506
+#   @jhawthorn Fix ObjectSpace.dump with super() callinfo https://github.com/ruby/ruby/pull/8630
+#   @k0kubun YJIT: RubyVM::YJIT.enable https://github.com/ruby/ruby/pull/8705
+
+install_package "openssl-3.1.2" "https://www.openssl.org/source/openssl-3.1.2.tar.gz#a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539" openssl --if needs_openssl_102_300
+install_git "ruby-3.3.0-preview2-pshopify3" "https://github.com/Shopify/ruby.git" "v3.3.0-preview2-pshopify3" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl


### PR DESCRIPTION
This backports `RubyVM::YJIT.enable` https://github.com/ruby/ruby/pull/8705 so that SFR's 3.3.0-preview2 can use the same thing as master when master is updated. For safe migration, this backport keeps `--yjit-pause` and `RubyVM::YJIT.resume`.

Diff: https://github.com/shopify/ruby/compare/v3.3.0-preview2-pshopify2...v3.3.0-preview2-pshopify3