### PR TITLE
Add definition for latest TruffleRuby GFTC development builds

### DIFF
--- a/rubies/truffleruby-gftc-dev
+++ b/rubies/truffleruby-gftc-dev
@@ -1,0 +1,19 @@
+platform="$(uname -s)-$(uname -m)"
+case $platform in
+Linux-x86_64)
+  install_package "truffleruby-gftc-dev" "https://github.com/graalvm/oracle-graalvm-dev-builds/releases/latest/download/truffleruby-dev-linux-amd64.tar.gz" truffleruby
+  ;;
+Linux-aarch64)
+  install_package "truffleruby-gftc-dev" "https://github.com/graalvm/oracle-graalvm-dev-builds/releases/latest/download/truffleruby-dev-linux-aarch64.tar.gz" truffleruby
+  ;;
+Darwin-x86_64)
+  install_package "truffleruby-gftc-dev" "https://github.com/graalvm/oracle-graalvm-dev-builds/releases/latest/download/truffleruby-dev-macos-amd64.tar.gz" truffleruby
+  ;;
+Darwin-arm64)
+  install_package "truffleruby-gftc-dev" "https://github.com/graalvm/oracle-graalvm-dev-builds/releases/latest/download/truffleruby-dev-macos-aarch64.tar.gz" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported platform: $platform"
+  return 1
+  ;;
+esac

--- a/test/shopify_ruby_definitions/test_ruby_versions.rb
+++ b/test/shopify_ruby_definitions/test_ruby_versions.rb
@@ -15,7 +15,7 @@ module ShopifyRubyDefinitions
       end
 
       truffleruby_versions.each do |v|
-        assert_match(/\Atruffleruby(?:\+graalvm)?\-\d+\.\d+\.\d+(?:\-ce)?\z/, v)
+        assert_match(/\Atruffleruby(?:\+graalvm|-gftc)?(\-\d+\.\d+\.\d+|-dev)(?:\-ce)?\z/, v)
       end
     end
 


### PR DESCRIPTION
tested on an M1 and spin
`truffleruby 24.1.0-dev-1f80340c, like ruby 3.2.2, Oracle GraalVM Native`