### PR TITLE
Add Ruby 3.4.0-pshopify-preview3

### DIFF
--- a/rubies/3.4.0-pshopify-preview3
+++ b/rubies/3.4.0-pshopify-preview3
@@ -1,0 +1,4 @@
+# https://github.com/Shopify/ruby/tree/v3.4.0-pshopify-preview3 / https://github.com/Shopify/ruby/commit/744cf0549ef508e2ba5ebc68749ff02edbd3f032
+
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
+install_git "ruby-3.4.0-pshopify-preview3" "https://github.com/Shopify/ruby.git" "v3.4.0-pshopify-preview3" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl


### PR DESCRIPTION
I want to upgrade SFR's non-experimental Ruby version to 3.4, but `v3.4.0-pshopify-preview2` is missing a few bugfixes.

Instead of backporting patches to the old Ruby, I want to cut a new preview version from the latest master.