### PR TITLE
3.4.0-pshopify-preview4

### DIFF
--- a/rubies/3.4.0-pshopify-preview4
+++ b/rubies/3.4.0-pshopify-preview4
@@ -1,0 +1,4 @@
+# https://github.com/Shopify/ruby/tree/v3.4.0-pshopify-preview4 / https://github.com/Shopify/ruby/commit/0cf4704ecbb36965ff614afada13d74ed09f7a4d
+
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
+install_git "ruby-3.4.0-pshopify-preview4" "https://github.com/Shopify/ruby.git" "v3.4.0-pshopify-preview4" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl


### PR DESCRIPTION
Same as 3.4.0-pshopify-preview2 but with a backport of https://github.com/ruby/ruby/pull/11356

(I ignored preview 3 because we ended not running it)