### PR TITLE
Fix the TruffleRuby+GraalVM integration builds.

### DIFF
--- a/rubies/truffleruby+graalvm-integration
+++ b/rubies/truffleruby+graalvm-integration
@@ -1,8 +1,8 @@
 build_package_jt() {
     unset GEM_HOME GEM_PATH JAVA_HOME
-    JT_IMPORTS_DONT_ASK=true bin/jt build --env jvm
-    graalvm=$(bin/jt --use jvm ruby-home)
+    JT_IMPORTS_DONT_ASK=true bin/jt build --env jvm-ce
+    graalvm=$(bin/jt --use jvm-ce ruby-home)
     mv "$graalvm" "$PREFIX_PATH"
 }
 
-install_git "truffleruby+graalvm-integration" "https://github.com/Shopify/truffleruby.git" "integration" graalvm jt
+install_git "truffleruby+graalvm-integration" "https://github.com/Shopify/truffleruby.git" "integration" jt


### PR DESCRIPTION
The build step referred to a removed function and we were inadvertently using the JVM without the Graal compiler.