### PR TITLE
Create pshopify2 for 4.0.2 to get fiber GC patch

### DIFF
--- a/lib/tasks/pshopify.rake
+++ b/lib/tasks/pshopify.rake
@@ -164,7 +164,7 @@ class PshopifyDefinitionCreator
 
     lines << ""
     lines << openssl_line
-    lines << "install_git \"ruby-#{@pshopify_version}\" \"#{SHOPIFY_RUBY_GIT_URL}\" \"#{@tag}\"" \
+    lines << "install_git \"ruby-#{@pshopify_version}\" \"#{SHOPIFY_RUBY_GIT_URL}\" \"#{@tag}\" " \
       "autoconf enable_shared standard"
     lines << ""
 

--- a/rubies/4.0.2-pshopify2
+++ b/rubies/4.0.2-pshopify2
@@ -1,0 +1,8 @@
+# https://github.com/Shopify/ruby/compare/v4.0.2-pshopify1...Shopify:v4.0.2-pshopify2
+
+# Based off v4.0.2-pshopify1, with the following changes:
+#   * Simplify subclasses list, remove from Box
+#   * Run GC if fiber pool expansion fails. (#16535)
+
+install_package "openssl-3.0.19" "https://github.com/openssl/openssl/releases/download/openssl-3.0.19/openssl-3.0.19.tar.gz#fa5a4143b8aae18be53ef2f3caf29a2e0747430b8bc74d32d88335b94ab63072" openssl --if needs_openssl:1.1.1-3.x.x
+install_git "ruby-4.0.2-pshopify2" "https://github.com/Shopify/ruby.git" "v4.0.2-pshopify2" autoconf enable_shared standard


### PR DESCRIPTION
## Why?

This patch from @samuel-williams-shopify unblocks work for Storefront. We want it to be available on 4.0.2 before the next release cycle.

> Run GC if fiber pool expansion fails. 
https://github.com/ruby/ruby/pull/16535

## Approach

* Used @rwstauner's new Rake task to build the files. Worked like a charm! 🙇 Tiny whitespace fix is included because it renderer as `"v4.0.2-pshopify2"autoconf` which caused `--branch v4.0.1-pshopify2autoconf` in GH Action
* Applied the patch only to `4.0.2`, because `4.0.1` is anyways tracking the exact same changes, so Storefront will update from `4.0.1-pshopify1` to `4.0.2-pshopify2`
* Manually removed a line from the documented changeset. This is because the manual patch from `4.0.2-pshopify1` has landed on `ruby/ruby`'s `ruby_4_0` backport branch. The divergence between both branches caused the change `Ensure fiber stack is freed in all cases, if the fiber is terminated. (#16416)` to be included in the changelog again, even though `4.0.2-pshopify1` already has that fix.