### PR TITLE
Create 4.0.2-pshopify3

### DIFF
--- a/rubies/4.0.2-pshopify3
+++ b/rubies/4.0.2-pshopify3
@@ -1,0 +1,7 @@
+# https://github.com/Shopify/ruby/compare/v4.0.2-pshopify2...Shopify:v4.0.2-pshopify3
+
+# Based off v4.0.2-pshopify2, with the following changes:
+#   * gc: prevent LTO from eliminating rb_gc_before_fork
+
+install_package "openssl-3.0.19" "https://github.com/openssl/openssl/releases/download/openssl-3.0.19/openssl-3.0.19.tar.gz#fa5a4143b8aae18be53ef2f3caf29a2e0747430b8bc74d32d88335b94ab63072" openssl --if needs_openssl:1.1.1-3.x.x
+install_git "ruby-4.0.2-pshopify3" "https://github.com/Shopify/ruby.git" "v4.0.2-pshopify3" autoconf enable_shared standard


### PR DESCRIPTION
GCC LTO fork barrier fix | [compare](https://github.com/Shopify/ruby/compare/v4.0.2-pshopify2...Shopify:v4.0.2-pshopify3)