### PR TITLE
Add v4.0.5-pshopify3

### DIFF
--- a/rubies/4.0.5-pshopify3
+++ b/rubies/4.0.5-pshopify3
@@ -1,0 +1,10 @@
+# https://github.com/Shopify/ruby/compare/v4.0.5-pshopify2...Shopify:v4.0.5-pshopify3
+
+# Based off v4.0.5-pshopify2, with the following changes:
+#   * [DOC] Fix Thread::Mutex#unlock doc
+#   * YJIT: Fix version_map use-after-free from mutable aliasing UB
+#   * ci: install ruby-devel and fiddle gem for Cygwin build
+#   * Use a hint avoid the optimistic sched lock drop/reacquire
+
+install_package "openssl-3.0.20" "https://github.com/openssl/openssl/releases/download/openssl-3.0.20/openssl-3.0.20.tar.gz#c80a01dfc70ece4dc21168932c37739042d404d46ccc81a5986dd75314ecda6f" openssl --if needs_openssl:1.1.1-3.x.x
+install_git "ruby-4.0.5-pshopify3" "https://github.com/Shopify/ruby.git" "v4.0.5-pshopify3" autoconf enable_shared standard


### PR DESCRIPTION
Adds the ruby-build definition for Shopify/ruby branch v4.0.5-pshopify3.

https://github.com/Shopify/ruby/compare/v4.0.5-pshopify2...Shopify:v4.0.5-pshopify3